### PR TITLE
Push commentにbranch名のlinkを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ jobs:
             #closes
             #closed
           push_comment_template: |-
-            <%= commits[0].author.name %>さんがプッシュしました
+            <%= commits[0].author.name %>さんが[<%= ref.name %>](<%= ref.url %>)にプッシュしました
             <% commits.forEach(commit=>{ %>
             + <%= commit.comment %> ([<% print(commit.id.slice(0, 7)) %>](<%= commit.url %>))<% }); %>
           commit_message_reg_template: "\
@@ -113,6 +113,13 @@ jobs:
 
 <summary>使用可能な変数</summary>
 
+| 変数名    | 型             |
+| --------- | -------------- |
+| `commits` | ParsedCommit[] |
+| `ref`     | ParsedRef      |
+
+ParsedCommit
+
 | 変数名      | 型        |
 | ----------- | --------- |
 | `id`        | string    |
@@ -131,6 +138,13 @@ jobs:
 | `keywords`  | string    |
 | `isFix`     | boolean   |
 | `isClose`   | boolean   |
+
+ParsedRef
+
+| 変数名 | 型     |
+| ------ | ------ |
+| `name` | string |
+| `url`  | string |
 
 Committer
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Backlog Notify
-        uses: bicstone/backlog-notify@v2
+        uses: bicstone/backlog-notify@v3
         with:
           # The following are required settings
           project_key: PROJECT_KEY

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     description: The template for backlog issue comment on push events
     required: false
     default: |-
-      <%= commits[0].author.name %>さんがプッシュしました
+      <%= commits[0].author.name %>さんが[<%= ref.name %>](<%= ref.url %>)にプッシュしました
       <% commits.forEach(commit=>{ %>
       + <%= commit.comment %> ([<% print(commit.id.slice(0, 7)) %>](<%= commit.url %>))<% }); %>
   commit_message_reg_template:

--- a/src/getConfigs.ts
+++ b/src/getConfigs.ts
@@ -38,7 +38,7 @@ export const getConfigs = (): Configs => {
       : ["#close", "#closes", "#closed"],
     pushCommentTemplate:
       core.getInput("push_comment_template") ||
-      "<%= commits[0].author.name %>さんがプッシュしました" +
+      "<%= commits[0].author.name %>さんが[<%= ref.name %>](<%= ref.url %>)にプッシュしました" +
         "\n" +
         "<% commits.forEach(commit=>{ %>" +
         "\n" +

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import * as core from "@actions/core"
 import { fetchEvent } from "./fetchEvent"
 import { getConfigs } from "./getConfigs"
 import { parseCommits } from "./parseCommits"
+import { parseRef } from "./parseRef"
 import { postComments } from "./postComments"
 
 const runAction = async (): Promise<string> => {
@@ -41,10 +42,19 @@ const runAction = async (): Promise<string> => {
   }
   core.endGroup()
 
+  // parse ref, repository
+  core.startGroup(`Push先の確認中`)
+  const parsedRef = parseRef(event.ref, event.repository.html_url)
+  if (!parsedRef) {
+    return "Git referenceの解析に失敗しました。"
+  }
+  core.endGroup()
+
   // post comments
   core.startGroup(`コメント送信中`)
   await postComments({
     parsedCommits,
+    parsedRef,
     pushCommentTemplate,
     fixStatusId,
     closeStatusId,

--- a/src/parseRef.ts
+++ b/src/parseRef.ts
@@ -1,0 +1,28 @@
+import template from "lodash.template"
+
+const refReg = /refs\/[a-z]*\/(.*)/
+const refUrlTemplate = template("<%= repositoryHtmlUrl %>/tree/<%= name %>")
+
+export type ParsedRef = {
+  name: string
+  url: string
+}
+
+/**
+ * Parse tree name and url from the event ref and repository html url
+ * @param ref The full git ref that was pushed. Example: `refs/heads/main` or `refs/tags/v3.14.1`.
+ * @param repositoryHtmlUrl HTML URL of the repository.
+ * @returns
+ */
+export const parseRef = (
+  ref: string,
+  repositoryHtmlUrl: string
+): ParsedRef | undefined => {
+  // e.g. Get name `feature/foo ` for ref `refs/heads/feature/foo`
+  const name = ref.match(refReg)?.[1]
+  if (!name) return
+
+  const url = refUrlTemplate({ repositoryHtmlUrl, name })
+
+  return { name, url }
+}

--- a/test/getConfigs.spec.ts
+++ b/test/getConfigs.spec.ts
@@ -75,7 +75,7 @@ describe("getConfigs", () => {
     }
   )
 
-  test("getConfigs return configs for current version when we set configs as of version 1.1.1", () => {
+  test("getConfigs return configs for current version when we set configs as of version 2.x.x", () => {
     Object.keys(requiredEnv).forEach((key) => {
       process.env[`INPUT_${key}`] = ``
     })
@@ -84,12 +84,12 @@ describe("getConfigs", () => {
     })
     expect(getConfigs()).toStrictEqual({
       ...configs,
-      // parseCommits.ts of version 1.1.1
+      // parseCommits.ts of version 2.x.x
       fixKeywords: ["#fix", "#fixes", "#fixed"],
       closeKeywords: ["#close", "#closes", "#closed"],
-      // postComments.ts of version 1.1.1
+      // postComments.ts of version 2.x.x
       pushCommentTemplate:
-        "<%= commits[0].author.name %>さんがプッシュしました" +
+        "<%= commits[0].author.name %>さんが[<%= ref.name %>](<%= ref.url %>)にプッシュしました" +
         "\n" +
         "<% commits.forEach(commit=>{ %>" +
         "\n" +

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -157,6 +157,21 @@ describe("main", () => {
     )
   })
 
+  test("main not continue and resolve processing when the event.ref is invalid", async () => {
+    const pushInvalidRef = {
+      ...push,
+      ref: "invalid-ref",
+    } as PushEvent
+    mocked(fetchEvent.fetchEvent).mockImplementation(() => ({
+      event: pushInvalidRef,
+    }))
+    await expect(main()).resolves.not.toThrow()
+    expect(core.info).toHaveBeenCalledTimes(1)
+    expect(core.info).toHaveBeenCalledWith(
+      "Git referenceの解析に失敗しました。"
+    )
+  })
+
   test("main calls setFailed when an error", async () => {
     const error = Error("error!")
     mocked(fetchEvent.fetchEvent).mockImplementation(() => {

--- a/test/postCommits.spec.ts
+++ b/test/postCommits.spec.ts
@@ -3,13 +3,14 @@ import axios, { AxiosResponse } from "axios"
 import { mocked } from "jest-mock"
 import { ParsedCommits } from "../src/parseCommits"
 import { postComments, Response } from "../src/postComments"
+import { ParsedRef } from "../src/parseRef"
 
 jest.mock("axios")
 
 const fixStatusId = "fixStatusId"
 const closeStatusId = "closeStatusId"
 const pushCommentTemplate =
-  "<%= commits[0].author.name %>さんがプッシュしました" +
+  "<%= commits[0].author.name %>さんが[<%= ref.name %>](<%= ref.url %>)にプッシュしました" +
   "\n" +
   "<% commits.forEach(commit=>{ %>" +
   "\n" +
@@ -53,6 +54,10 @@ const baseCommits: ParsedCommits = {
   [issueKey]: [baseCommit],
 }
 
+const baseParsedRef: ParsedRef = {
+  name: "branch-name",
+  url: "https://example.com/foo/bar/tree/branch-name",
+}
 const axiosResponse: AxiosResponse = {
   data: {},
   status: 200,
@@ -70,9 +75,10 @@ describe("postComments", () => {
   test("parseCommits post a comment to Backlog API", () => {
     const endpoint = `https://${apiHost}/api/v2/issues/${issueKey}?apiKey=${apiKey}`
     const parsedCommits: ParsedCommits = baseCommits
+    const parsedRef: ParsedRef = baseParsedRef
     const body = {
       comment:
-        `${baseCommit.author.name}さんがプッシュしました` +
+        `${baseCommit.author.name}さんが[${baseParsedRef.name}](${baseParsedRef.url})にプッシュしました` +
         "\n" +
         "\n" +
         `+ ${baseCommit.comment} ` +
@@ -90,6 +96,7 @@ describe("postComments", () => {
     expect(
       postComments({
         parsedCommits,
+        parsedRef,
         fixStatusId,
         closeStatusId,
         pushCommentTemplate,
@@ -114,9 +121,10 @@ describe("postComments", () => {
         },
       ],
     }
+    const parsedRef: ParsedRef = baseParsedRef
     const body = {
       comment:
-        `${baseCommit.author.name}さんがプッシュしました` +
+        `${baseCommit.author.name}さんが[${baseParsedRef.name}](${baseParsedRef.url})にプッシュしました` +
         "\n" +
         "\n" +
         `+ ${baseCommit.comment} ` +
@@ -135,6 +143,7 @@ describe("postComments", () => {
     expect(
       postComments({
         parsedCommits,
+        parsedRef,
         fixStatusId,
         closeStatusId,
         pushCommentTemplate,
@@ -159,9 +168,10 @@ describe("postComments", () => {
         },
       ],
     }
+    const parsedRef: ParsedRef = baseParsedRef
     const body = {
       comment:
-        `${baseCommit.author.name}さんがプッシュしました` +
+        `${baseCommit.author.name}さんが[${baseParsedRef.name}](${baseParsedRef.url})にプッシュしました` +
         "\n" +
         "\n" +
         `+ ${baseCommit.comment} ` +
@@ -180,6 +190,7 @@ describe("postComments", () => {
     expect(
       postComments({
         parsedCommits,
+        parsedRef,
         fixStatusId,
         closeStatusId,
         pushCommentTemplate,
@@ -214,6 +225,7 @@ describe("postComments", () => {
         },
       ],
     }
+    const parsedRef: ParsedRef = baseParsedRef
     const response1: Response = {
       response: axiosResponse,
       commits: parsedCommits[`${projectKey}-1`],
@@ -232,6 +244,7 @@ describe("postComments", () => {
     expect(
       postComments({
         parsedCommits,
+        parsedRef,
         fixStatusId,
         closeStatusId,
         pushCommentTemplate,


### PR DESCRIPTION
Backlogに記載されるプッシュコメントにブランチ名のGitHubへのリンクを追加しました。

issue #33 の一部を解消します。
>コメントのデフォルトを変更し、ブランチ名を表示することで、コメントからどのブランチにプッシュされたかがわかる

ご検討をお願いして良いでしょうか？