### PR TITLE
chore(renovate): typescript を v6 系に固定する

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -2,6 +2,11 @@
   "extends": ["github>bicstone/renovate-config"],
   "packageRules": [
     {
+      "allowedVersions": "<7",
+      "description": "typescript-eslint が TypeScript 7 に未対応のため v6 系に固定する (対応後にこのルールを削除する)",
+      "matchPackageNames": ["typescript"]
+    },
+    {
       "automerge": true,
       "groupName": "devDependencies",
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
## 概要

typescript-eslint が TypeScript 7 に未対応のため、Renovate による typescript v7 への更新を除外します。

対象: #462

## 背景

TypeScript 7 (tsgo) には公開 API がまだ存在せず、typescript-eslint 側で対応できない状態です。そのため v7 に更新すると eslint が実行時にクラッシュします。

```
TypeError: Cannot read properties of undefined (reading 'Cjs')
  at @typescript-eslint/typescript-estree/dist/create-program/shared.js:59:18
```

- typescript-eslint の peerDependencies は `typescript <6.1.0`
- [typescript-eslint#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518) は「TS 7 の API が無いため対応不可」として NOT_PLANNED でクローズ
- 追跡 issue: [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940)

メンテナのコメントによると、ESLint の非同期パーサー未対応・tsgo の安定化待ち・Go/WASM 境界の設計課題があり、typescript-eslint の次の 1〜2 メジャーバージョン以内での対応は見込めない状況です。

## 変更内容

`.renovaterc.json` に `allowedVersions: "<7"` のルールを追加。v6 系の minor/patch 更新は引き続き受け取ります。

## 解除条件

typescript-eslint が TypeScript 7 に対応したら、このルールを削除してください。[typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940) のクローズが目安です。

## 動作確認

- `renovate-config-validator` で検証済み
- `prettier --check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WC1L2zHqdjqC2d5eZhBEiG
